### PR TITLE
README.md Typo and consistency fixes to the VerticalScrollingFrame gu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ local choices = {
 	{Id = "choice3", Text = "c"}
 }
 
-local scrollFrame = ScrollingFrame.new("suffix")
+local scrollFrame = VerticalScrollingFrame.new("suffix")
 
 local listFrame = VerticallyScalingListFrame.new("suffix")
 local collapse = CollapsibleTitledSection.new("suffix", "titleText", true, true, true)
@@ -337,7 +337,7 @@ listFrame:AddChild(collapse:GetSectionFrame()) -- add child to expanding Vertica
 
 listFrame:AddBottomPadding() -- add padding to VerticallyScalingListFrame
 
-listFrame:GetFrame().Parent = scrollFrame:GetContentFrame() -- scroll content will be the VerticallyScalingListFrame
+listFrame:GetFrame().Parent = scrollFrame:GetContentsFrame() -- scroll content will be the VerticallyScalingListFrame
 scrollFrame:GetSectionFrame().Parent = widgetGui -- set the section parent
 ```
 


### PR DESCRIPTION
…ide.

The VerticalScrollingFrame guide has a few mistakes.

On line 340 "GetContentFrame()" contains a typo error, and has been fixed appropriately be the GetContentsFrame() function. "ScrollingFrame" on Line 319 is also an inconsistency error, meant to match up with the other Modules. This has been renamed to VerticalScrollingFrame.